### PR TITLE
Philip/personalized products fix

### DIFF
--- a/Adapter/Search.php
+++ b/Adapter/Search.php
@@ -115,16 +115,27 @@ class Search implements AdapterInterface
                 $documents = $this->getDocuments($table);
                 $newDocuments = [];
                 
+                $documentsUnset = [];
                 if (array_key_exists('personalizedProducts', $result)) {
                     $parsedPersonalProducts = [];
                     $personalProducts = $result['personalizedProducts'];
+
                     foreach ($personalProducts as $item) {
                         if (array_key_exists($item['Id'], $documents)) {
                             $parsedPersonalProducts[] = $item;
+                            $documentsUnset[] = $documents[$item['Id']];
+                            unset($documents[$item['Id']]);
                         }
                     }
+
+                    if (count($documents) == 0 && count($parsedPersonalProducts) > 0) {
+                        $documents = $documentsUnset;
+                        $parsedPersonalProducts = [];
+                    }
+
                     $result['personalizedProducts'] = $parsedPersonalProducts;
                     $this->service->updateSearchResult($result);
+                    
                 }
             }
         } else {

--- a/Adapter/Search.php
+++ b/Adapter/Search.php
@@ -121,7 +121,6 @@ class Search implements AdapterInterface
                     foreach ($personalProducts as $item) {
                         if (array_key_exists($item['Id'], $documents)) {
                             $parsedPersonalProducts[] = $item;
-                            unset($documents[$item['Id']]);
                         }
                     }
                     $result['personalizedProducts'] = $parsedPersonalProducts;

--- a/Plugin/Model/Config.php
+++ b/Plugin/Model/Config.php
@@ -1,0 +1,27 @@
+<?php
+namespace Pureclarity\Core\Plugin\Model;
+
+use Magento\Store\Model\StoreManagerInterface;
+
+class Config  {
+
+    protected $_storeManager;
+
+    public function __construct(
+        StoreManagerInterface $storeManager
+    ) {
+        $this->_storeManager = $storeManager;
+    }
+
+
+    public function afterGetAttributeUsedForSortByArray(\Magento\Catalog\Model\Config $catalogConfig, $options)
+    {
+        //Changing label
+        $customOption['relevance'] = __( 'Relevance' );
+
+        //Merge default sorting options with custom options
+        $options = array_merge($customOption, $options);
+     
+        return $options;
+    }
+}

--- a/Plugin/Model/Product/ProductList/Toolbar.php
+++ b/Plugin/Model/Product/ProductList/Toolbar.php
@@ -1,0 +1,33 @@
+<?php
+namespace Pureclarity\Core\Plugin\Model\Product\ProductList;
+
+
+class Toolbar 
+{
+    public function __construct(
+        \Magento\Framework\App\Request\Http $request
+    ) { }  
+    
+    // Overwrites magentos sort by logic to use our order.
+    public function afterSetCollection(
+        \Magento\Catalog\Block\Product\ProductList\Toolbar $toolbar,
+        $interceptor,
+        $collection        
+    ) {
+        return $collection;
+    }
+
+    // Sets the default sort by value to the new relevance sort by to match general search
+    public function beforeGetCurrentOrder(
+        \Magento\Catalog\Block\Product\ProductList\Toolbar $toolbar
+    ) {
+        $toolbar->setDefaultOrder('relevance');      
+    }
+
+    // Sets the default sort by direction to descending
+    public function beforeGetCurrentDirection(
+        \Magento\Catalog\Block\Product\ProductList\Toolbar $toolbar
+    ) {
+        $toolbar->setDefaultDirection('desc');      
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -21,6 +21,12 @@
     <type name="Magento\Catalog\Model\Category\DataProvider">
         <plugin name="pureclarity_core_dataprovider_plugin" type="Pureclarity\Core\Plugin\Category\DataProvider" />
     </type>
+    <type name="Magento\Catalog\Model\Config">
+        <plugin name="pureclarity_core_toolbar_config" type="Pureclarity\Core\Plugin\Model\Config" />
+    </type>
+    <type name="Magento\Catalog\Block\Product\ProductList\Toolbar">
+        <plugin name="pureclarity_core_toolbar" type="Pureclarity\Core\Plugin\Model\Product\ProductList\Toolbar" />
+    </type>
     <preference for="Magento\Framework\Search\Adapter\Mysql\Adapter" type="Pureclarity\Core\Adapter\Search" />
 
     <type name="Magento\Framework\HTTP\PhpEnvironment\RemoteAddress">


### PR DESCRIPTION
Fixed product listing rules not showing on category pages by overwriting the way that magento displays the project and inserting our own sorting order.