### PR TITLE
preventing js error when module disabled

### DIFF
--- a/view/frontend/web/js/pcjs-init.js
+++ b/view/frontend/web/js/pcjs-init.js
@@ -1,6 +1,6 @@
 require(['jquery', 'priceBox'], function ($, priceBox) {
     // Before initialise, check we're active
-    if (!pureclarityConfig.state.isActive) {
+    if (typeof pureclarityConfig === 'undefined' || !pureclarityConfig.state.isActive) {
         return; 
     }
 

--- a/view/frontend/web/js/pcjs.js
+++ b/view/frontend/web/js/pcjs.js
@@ -1,6 +1,6 @@
 define(['jquery', 'priceBox'], function ($, priceBox) {
     // Before initialise, check we're active
-    if (!pureclarityConfig.state.isActive) {
+    if (typeof pureclarityConfig === 'undefined' || !pureclarityConfig.state.isActive) {
         return; 
     }
 


### PR DESCRIPTION
Added extra protection to js scripts to prevent javascript error if pureclarityconfig object not present