### PR TITLE
Gareth/bmz context serverside

### DIFF
--- a/Adapter/Search.php
+++ b/Adapter/Search.php
@@ -135,15 +135,16 @@ class Search implements AdapterInterface
 
                     $result['personalizedProducts'] = $parsedPersonalProducts;
                     $this->service->updateSearchResult($result);
-                    
                 }
             }
-        } else {
+        }
+
+        // If no results returned from PC or search / serverside disabled then default to Magento search
+        if ($table === null) {
             $query = $this->mapper->buildQuery($request);
             $table = $temporaryStorage->storeDocumentsFromSelect($query);
             $documents = $this->getDocuments($table);
         }
-        
  
         $aggregations = $this->aggregationBuilder->build($request, $table);
  

--- a/Helper/Service.php
+++ b/Helper/Service.php
@@ -81,9 +81,15 @@ class Service extends \Magento\Framework\App\Helper\AbstractHelper
         $this->action = $action;
     }
 
-    public function addZone($zoneId)
+    public function addZone($zoneId, $data = [])
     {
-        $this->zones[] = [ "id" => $zoneId ];
+        $zone = [ 'id' => $zoneId ];
+        
+        if (!empty($data)) {
+            $zone['data'] = $data;
+        }
+        
+        $this->zones[] = $zone;
     }
 
     public function addTrackingEvent($event, $data)
@@ -104,7 +110,6 @@ class Service extends \Magento\Framework\App\Helper\AbstractHelper
         $this->sort = $sort;
         $this->size = $size;
     }
-
 
     public function processSearch()
     {
@@ -266,7 +271,6 @@ class Service extends \Magento\Framework\App\Helper\AbstractHelper
         try {
             $response = $client->send();
             $this->result = json_decode($response->getBody(), true);
-        
             if (array_key_exists('errors', $this->result)) {
                 $this->logger->error('PURECLARITY ERROR: Errors return from PureClarity - ' . var_export($this->result['errors'], true));
                 return;


### PR DESCRIPTION
Tweaked BMZ block building so that it stores the zone context data to send with the serverside request or output with the html for client side.

Improved search adapter to cope with a bad response from PC, will now default to Magento search if serverside & search enabled but got no response from PC.