### PR TITLE
Gareth/serverside content zones

### DIFF
--- a/Model/Serverside/Request/Frontend.php
+++ b/Model/Serverside/Request/Frontend.php
@@ -288,8 +288,10 @@ class Frontend
         if (isset($result['zones'])) {
             $this->productData->setCurrentUrl($request->getCurrentUrl());
             foreach ($result['zones'] as $zoneId => $zone) {
-                $result['zones'][$zoneId]['items'] = $this->productData->getProductData($zone);
-                unset($result['zones'][$zoneId]['data']['items']);
+                if ($zone['type'] === 'recommender-product') {
+                    $result['zones'][$zoneId]['items'] = $this->productData->getProductData($zone);
+                    unset($result['zones'][$zoneId]['data']['items']);
+                }
             }
         }
 

--- a/Model/Serverside/Response/ProductData.php
+++ b/Model/Serverside/Response/ProductData.php
@@ -112,10 +112,6 @@ class ProductData
      */
     public function getProductData($zone)
     {
-        if ($zone['type'] !== 'recommender-product') {
-            return $zone['items'];
-        }
-
         $skus = [];
         $skuKeys = [];
         foreach ($zone['items'] as $key => $item) {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -44,8 +44,8 @@
                 <label>Mode</label>
                 <comment><![CDATA[
                     Choose the Mode that PureClarity will work in:<br />
-                    <br /><strong>Serverside</strong>: Populate Product recommenders using Magento data after getting SKUs to show from PureClarity. Ideal for when you have complex pricing rules & logic.
                     <br /><strong>Client-side</strong>: All data and HTML for recommenders comes from the PureClarity servers.
+                    <br /><strong>Serverside</strong>: Populate Product recommenders using Magento data after getting SKUs to show from PureClarity. Ideal for when you have complex pricing rules & logic.
                 ]]></comment>
                 <field id="mode" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Mode</label>

--- a/view/frontend/web/js/pcjs-init.js
+++ b/view/frontend/web/js/pcjs-init.js
@@ -289,40 +289,46 @@ require([
 
                         if (data.zones[bmzId] && foundZones[bmzId] !== true) {
                             foundZones[bmzId] = true;
-                            for (var j=0; j<data.zones[bmzId].items.length; j++) {
-                                data.zones[bmzId].items[j]['formatted_price'] = priceUtils.formatPrice(data.zones[bmzId].items[j]['final_price'], pureclarityConfig.priceFormat);
-                            }
 
-                            var zoneConfig = {
-                                "name" : 'Pureclarity_Core/product-recommender',
-                                "data" : {
-                                    "template" : "Pureclarity_Core/product-recommender",
-                                    "zoneId" : bmzId,
-                                    "zoneData" : data.zones[bmzId],
-                                    "addToCartText" : translate('Add to Cart'),
-                                    "addToCompareText" : translate('Add to Compare'),
-                                    "addToWishlistText" : translate('Add to Wishlist')
+                            if (data.zones[bmzId].type !== 'product-recommender') {
+                                zone.html(data.zones[bmzId].html);
+                                zone.show();
+                            } else {
+                                for (var j=0; j<data.zones[bmzId].items.length; j++) {
+                                    data.zones[bmzId].items[j]['formatted_price'] = priceUtils.formatPrice(data.zones[bmzId].items[j]['final_price'], pureclarityConfig.priceFormat);
                                 }
-                            };
 
-                            var zoneConfigJson = JSON.stringify(zoneConfig);
-                            zone.attr('data-bind', 'template: ' + zoneConfigJson + '');
+                                var zoneConfig = {
+                                    "name" : 'Pureclarity_Core/product-recommender',
+                                    "data" : {
+                                        "template" : "Pureclarity_Core/product-recommender",
+                                        "zoneId" : bmzId,
+                                        "zoneData" : data.zones[bmzId],
+                                        "addToCartText" : translate('Add to Cart'),
+                                        "addToCompareText" : translate('Add to Compare'),
+                                        "addToWishlistText" : translate('Add to Wishlist')
+                                    }
+                                };
 
-                            ko.bindingHandlers.pcUpdateSwatches = {
-                                init: function(element) {
-                                    require(['Magento_Swatches/js/swatch-renderer', 'priceBox'], function () {
-                                        var items = $("[pureclarity-data-item]", element);
-                                        processZoneItems(items, false);
-                                    });
+                                var zoneConfigJson = JSON.stringify(zoneConfig);
+                                zone.attr('data-bind', 'template: ' + zoneConfigJson + '');
+
+                                ko.bindingHandlers.pcUpdateSwatches = {
+                                    init: function(element) {
+                                        require(['Magento_Swatches/js/swatch-renderer', 'priceBox'], function () {
+                                            var items = $("[pureclarity-data-item]", element);
+                                            processZoneItems(items, false);
+                                        });
+                                    }
+                                };
+
+                                if (document.readyState === 'complete') {
+                                    ko.applyBindings({}, zone[0]);
+                                    zone.trigger('contentUpdated');
                                 }
-                            };
 
-                            if (document.readyState === 'complete') {
-                                ko.applyBindings({}, zone[0]);
-                                zone.trigger('contentUpdated');
+                                zone.show();
                             }
-
-                            zone.show();
                         }
                     }
                 });


### PR DESCRIPTION
- change to Javascript processing of serverside results to just inject html of non-product recommender zones
- tweak to serverside results processing so non-product zones do not cause errors due to not having "items" array key
 - updating display of mode config to put client side first (as it's default)
