### PR TITLE
incremented version number due to submission issue (magento side)

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -19,7 +19,7 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class Data
 {
-    const CURRENT_VERSION = '4.0.0';
+    const CURRENT_VERSION = '4.0.1';
     const PROGRESS_FILE_BASE_NAME = 'pureclarity-feed-progress-';
 
     /** @var StoreManagerInterface $storeManager */

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PureClarity Intelligent Personalization",
     "type": "magento2-module",
     "license": ["OSL-3.0"],
-    "version": "4.0.0",
+    "version": "4.0.1",
     "require": {
         "ext-curl": "*",
         "magento/framework": "100.1.*|101.0.*|102.0.*",


### PR DESCRIPTION
Core issue in magento submission meant we had to cancel 4.0.0 release. It won't let us resubmit 4.0.0 so have to move to 4.0.1