### PR TITLE
Serverside user agent fix

### DIFF
--- a/Helper/Service.php
+++ b/Helper/Service.php
@@ -280,7 +280,14 @@ class Service extends \Magento\Framework\App\Helper\AbstractHelper
                 ])
             ->setMethod('POST')
             ->setRawBody(Json::encode($requestBody));
-        
+
+        if (isset($requestBody['userAgent'])) {
+            $client->setHeaders([
+                'Content-Type' => 'application/json',
+                'user-agent' => $requestBody['userAgent']
+            ]);
+        }
+
         try {
             $response = $client->send();
             $this->result = json_decode($response->getBody(), true);


### PR DESCRIPTION
Added user-agent setting to serverside request headers, so traffic doesnt get wrongly classed as a bot by PC with newer versions of Magento