### PR TITLE
Feed runner improvements

### DIFF
--- a/Api/FeedDataManagementInterface.php
+++ b/Api/FeedDataManagementInterface.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace Pureclarity\Core\Api;
 
+use Magento\Store\Api\Data\StoreInterface;
+
 interface FeedDataManagementInterface
 {
     /**
@@ -18,17 +20,17 @@ interface FeedDataManagementInterface
 
     /**
      * Returns the total number of pages in this feed
-     * @param int $storeId
+     * @param StoreInterface $store
      * @return int
      */
-    public function getTotalPages(int $storeId): int;
+    public function getTotalPages(StoreInterface $store): int;
 
     /**
      * Returns a page of feed data
      *
-     * @param int $storeId
+     * @param StoreInterface $store
      * @param int $pageNum
      * @return mixed[]
      */
-    public function getPageData(int $storeId, int $pageNum): array;
+    public function getPageData(StoreInterface $store, int $pageNum): array;
 }

--- a/Api/FeedManagementInterface.php
+++ b/Api/FeedManagementInterface.php
@@ -41,4 +41,9 @@ interface FeedManagementInterface
      * @return FeedRowDataManagementInterface
      */
     public function getRowDataHandler(): FeedRowDataManagementInterface;
+
+    /**
+     * Returns whether this feed requires app emulation
+     */
+    public function requiresEmulation(): bool;
 }

--- a/Api/FeedRowDataManagementInterface.php
+++ b/Api/FeedRowDataManagementInterface.php
@@ -7,13 +7,15 @@ declare(strict_types=1);
 
 namespace Pureclarity\Core\Api;
 
+use Magento\Store\Api\Data\StoreInterface;
+
 interface FeedRowDataManagementInterface
 {
     /**
      * Returns a formatted row of data for this feed
+     * @param StoreInterface $store
      * @param mixed $row
-     * @param int $storeId
      * @return array
      */
-    public function getRowData(int $storeId, $row): array;
+    public function getRowData(StoreInterface $store, $row): array;
 }

--- a/Model/Feed/Runner.php
+++ b/Model/Feed/Runner.php
@@ -235,7 +235,7 @@ class Runner
     private function handleFeed(FeedManagementInterface $feedHandler, StoreInterface $store, string $type) : void
     {
         $feedDataHandler = $feedHandler->getFeedDataHandler();
-        $pageCount = $feedDataHandler->getTotalPages((int)$store->getId());
+        $pageCount = $feedDataHandler->getTotalPages($store);
 
         if ($pageCount > 0) {
 
@@ -250,7 +250,7 @@ class Runner
 
             $rowDataHandler = $feedHandler->getRowDataHandler();
             for ($page = 1; $page <= $pageCount; $page++) {
-                $data = $feedDataHandler->getPageData((int)$store->getId(), $page);
+                $data = $feedDataHandler->getPageData($store, $page);
                 foreach ($data as $row) {
                     $rowData = $rowDataHandler->getRowData($store, $row);
                     if ($rowData) {

--- a/Model/Feed/Type/Brand.php
+++ b/Model/Feed/Type/Brand.php
@@ -102,4 +102,13 @@ class Brand implements FeedManagementInterface
     {
         return $this->rowDataHandler;
     }
+
+    /**
+     * Returns whether this feed requires emulation
+     * @return bool
+     */
+    public function requiresEmulation(): bool
+    {
+        return false;
+    }
 }

--- a/Model/Feed/Type/Category.php
+++ b/Model/Feed/Type/Category.php
@@ -93,4 +93,13 @@ class Category implements FeedManagementInterface
     {
         return $this->rowDataHandler;
     }
+
+    /**
+     * Returns whether this feed requires emulation
+     * @return bool
+     */
+    public function requiresEmulation(): bool
+    {
+        return false;
+    }
 }

--- a/Model/Feed/Type/Category/FeedData.php
+++ b/Model/Feed/Type/Category/FeedData.php
@@ -9,11 +9,9 @@ namespace Pureclarity\Core\Model\Feed\Type\Category;
 
 use Pureclarity\Core\Api\CategoryFeedDataManagementInterface;
 use Magento\Store\Api\Data\StoreInterface;
-use Magento\Store\Model\StoreManagerInterface;
 use Psr\Log\LoggerInterface;
 use Pureclarity\Core\Model\Feed\State\Error;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Catalog\Model\Category;
 use PureClarity\Api\Feed\Feed;
@@ -29,9 +27,6 @@ class FeedData implements CategoryFeedDataManagementInterface
     /** @var int */
     private const PAGE_SIZE = 50;
 
-    /** @var StoreInterface */
-    private $currentStore;
-
     /** @var Collection */
     private $collection;
 
@@ -44,25 +39,19 @@ class FeedData implements CategoryFeedDataManagementInterface
     /** @var CategoryCollectionFactory */
     private $collectionFactory;
 
-    /** @var StoreManagerInterface */
-    private $storeManager;
-
     /**
      * @param LoggerInterface $logger
      * @param Error $feedError
      * @param CategoryCollectionFactory $collectionFactory
-     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         LoggerInterface $logger,
         Error $feedError,
-        CategoryCollectionFactory $collectionFactory,
-        StoreManagerInterface $storeManager
+        CategoryCollectionFactory $collectionFactory
     ) {
         $this->logger            = $logger;
         $this->feedError         = $feedError;
         $this->collectionFactory = $collectionFactory;
-        $this->storeManager      = $storeManager;
     }
 
     /**
@@ -76,18 +65,18 @@ class FeedData implements CategoryFeedDataManagementInterface
 
     /**
      * Returns the total number of pages for the category feed
-     * @param int $storeId
+     * @param StoreInterface $store
      * @return int
      */
-    public function getTotalPages(int $storeId): int
+    public function getTotalPages(StoreInterface $store): int
     {
         $totalPages = 0;
         try {
-            $totalPages = $this->getCategoryCollection($storeId)->getLastPageNumber();
-        } catch (NoSuchEntityException | LocalizedException $e) {
+            $totalPages = $this->getCategoryCollection($store)->getLastPageNumber();
+        } catch (LocalizedException $e) {
             $error = 'Could not load categories: ' . $e->getMessage();
             $this->logger->error('PureClarity: ' . $error);
-            $this->feedError->saveFeedError($storeId, Feed::FEED_TYPE_CATEGORY, $error);
+            $this->feedError->saveFeedError((int)$store->getId(), Feed::FEED_TYPE_CATEGORY, $error);
         }
 
         return $totalPages;
@@ -95,22 +84,22 @@ class FeedData implements CategoryFeedDataManagementInterface
 
     /**
      * Loads a page of category data for the feed
-     * @param int $storeId
+     * @param StoreInterface $store
      * @param int $pageNum
      * @return Category[]
      */
-    public function getPageData(int $storeId, int $pageNum): array
+    public function getPageData(StoreInterface $store, int $pageNum): array
     {
         $customers = [];
         try {
-            $collection = $this->getCategoryCollection($storeId);
+            $collection = $this->getCategoryCollection($store);
             $collection->clear();
             $collection->setCurPage($pageNum);
             $customers = $collection->getItems();
-        } catch (NoSuchEntityException | LocalizedException $e) {
+        } catch (LocalizedException $e) {
             $error = 'Could not load categories: ' . $e->getMessage();
             $this->logger->error('PureClarity: ' . $error);
-            $this->feedError->saveFeedError($storeId, Feed::FEED_TYPE_CATEGORY, $error);
+            $this->feedError->saveFeedError((int)$store->getId(), Feed::FEED_TYPE_CATEGORY, $error);
         }
 
         return $customers;
@@ -118,30 +107,28 @@ class FeedData implements CategoryFeedDataManagementInterface
 
     /**
      * Returns the built category collection
-     * @param int $storeId
+     * @param StoreInterface $store
      * @return Collection
-     * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function getCategoryCollection(int $storeId): Collection
+    public function getCategoryCollection(StoreInterface $store): Collection
     {
         if ($this->collection === null) {
-            $this->collection = $this->buildCategoryCollection($storeId);
+            $this->collection = $this->buildCategoryCollection($store);
         }
         return $this->collection;
     }
 
     /**
      * Builds the collection for category feed
-     * @param int $storeId
+     * @param StoreInterface $store
      * @return Collection
-     * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function buildCategoryCollection(int $storeId): Collection
+    public function buildCategoryCollection(StoreInterface $store): Collection
     {
         $collection = $this->collectionFactory->create();
-        $collection->setStore($this->getCurrentStore($storeId));
+        $collection->setStore($store);
         $collection->addAttributeToSelect('name');
         $collection->addAttributeToSelect('is_active');
         $collection->addAttributeToSelect('image');
@@ -151,19 +138,5 @@ class FeedData implements CategoryFeedDataManagementInterface
         $collection->addUrlRewriteToResult();
         $collection->setPageSize($this->getPageSize());
         return $collection;
-    }
-
-    /**
-     * Gets a Store object for the given Store ID
-     * @param int $storeId
-     * @return StoreInterface
-     * @throws NoSuchEntityException
-     */
-    private function getCurrentStore(int $storeId): StoreInterface
-    {
-        if (empty($this->currentStore)) {
-            $this->currentStore = $this->storeManager->getStore($storeId);
-        }
-        return $this->currentStore;
     }
 }

--- a/Model/Feed/Type/Order.php
+++ b/Model/Feed/Type/Order.php
@@ -93,4 +93,13 @@ class Order implements FeedManagementInterface
     {
         return $this->rowDataHandler;
     }
+
+    /**
+     * Returns whether this feed requires emulation
+     * @return bool
+     */
+    public function requiresEmulation(): bool
+    {
+        return false;
+    }
 }

--- a/Model/Feed/Type/Order/RowData.php
+++ b/Model/Feed/Type/Order/RowData.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Pureclarity\Core\Model\Feed\Type\Order;
 
 use Magento\Sales\Model\Order;
+use Magento\Store\Api\Data\StoreInterface;
 use Pureclarity\Core\Api\OrderFeedRowDataManagementInterface;
 
 /**
@@ -19,20 +20,20 @@ class RowData implements OrderFeedRowDataManagementInterface
 {
     /**
      * Builds the order data for the order feed.
-     * @param int $storeId
-     * @param Order $order
+     * @param StoreInterface $store
+     * @param Order $row
      * @return array
      */
-    public function getRowData(int $storeId, $order): array
+    public function getRowData(StoreInterface $store, $row): array
     {
         $orderData = [];
 
-        $id = $order->getIncrementId();
-        $customerId = $order->getCustomerId();
-        $email = $order->getCustomerEmail();
-        $date = $order->getCreatedAt();
+        $id = $row->getIncrementId();
+        $customerId = $row->getCustomerId();
+        $email = $row->getCustomerEmail();
+        $date = $row->getCreatedAt();
 
-        foreach ($order->getAllVisibleItems() as $item) {
+        foreach ($row->getAllVisibleItems() as $item) {
             $orderData[] = [
                 'OrderID' => $id,
                 'UserId' => $customerId ?: '',

--- a/Model/Feed/Type/User.php
+++ b/Model/Feed/Type/User.php
@@ -93,4 +93,13 @@ class User implements FeedManagementInterface
     {
         return $this->rowDataHandler;
     }
+
+    /**
+     * Returns whether this feed requires emulation
+     * @return bool
+     */
+    public function requiresEmulation(): bool
+    {
+        return false;
+    }
 }

--- a/Model/Feed/Type/User/RowData.php
+++ b/Model/Feed/Type/User/RowData.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Pureclarity\Core\Model\Feed\Type\User;
 
+use Magento\Store\Api\Data\StoreInterface;
 use Pureclarity\Core\Api\UserFeedRowDataManagementInterface;
 use Magento\Customer\Model\ResourceModel\Group\CollectionFactory as CustomerGroupCollectionFactory;
 use Magento\Customer\Model\Customer;
@@ -35,37 +36,37 @@ class RowData implements UserFeedRowDataManagementInterface
 
     /**
      * Builds the customer data for the user feed.
-     * @param int $storeId
-     * @param Customer $customer
+     * @param StoreInterface $store
+     * @param Customer $row
      * @return array
      */
-    public function getRowData(int $storeId, $customer): array
+    public function getRowData(StoreInterface $store, $row): array
     {
         $customerGroups = $this->getCustomerGroups();
         $data = [
-            'UserId' => $customer->getId(),
-            'Email' => $customer->getEmail(),
-            'FirstName' => $customer->getFirstname(),
-            'LastName' => $customer->getLastname()
+            'UserId' => $row->getId(),
+            'Email' => $row->getEmail(),
+            'FirstName' => $row->getFirstname(),
+            'LastName' => $row->getLastname()
         ];
 
-        $prefix = $customer->getPrefix();
+        $prefix = $row->getPrefix();
         if ($prefix) {
             $data['Salutation'] = $prefix;
         }
 
-        $dob = $customer->getDob();
+        $dob = $row->getDob();
         if ($dob) {
             $data['DOB'] = $dob;
         }
 
-        $groupId = $customer->getGroupId();
+        $groupId = $row->getGroupId();
         if ($groupId && isset($customerGroups[$groupId])) {
             $data['Group'] = $customerGroups[$groupId]['label'];
             $data['GroupId'] = $groupId;
         }
 
-        $gender = $customer->getGender();
+        $gender = $row->getGender();
         switch ($gender) {
             case 1: // Male
                 $data['Gender'] = 'M';
@@ -75,9 +76,9 @@ class RowData implements UserFeedRowDataManagementInterface
                 break;
         }
 
-        $data['City'] = $customer->getData('city');
-        $data['State'] = $customer->getData('region');
-        $data['Country'] = $customer->getData('country_id');
+        $data['City'] = $row->getData('city');
+        $data['State'] = $row->getData('region');
+        $data['Country'] = $row->getData('country_id');
         return $data;
     }
 

--- a/Test/Unit/Model/Feed/RunnerTest.php
+++ b/Test/Unit/Model/Feed/RunnerTest.php
@@ -6,6 +6,10 @@
 
 namespace Pureclarity\Core\Test\Unit\Model\Feed;
 
+use Magento\Framework\App\Area;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Phrase;
+use Magento\Store\Api\Data\StoreInterface;
 use PHPUnit\Framework\TestCase;
 use Pureclarity\Core\Model\Feed\Runner;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -19,6 +23,8 @@ use Pureclarity\Core\Model\Feed\State\RunDate;
 use Pureclarity\Core\Model\Feed\State\Progress;
 use Pureclarity\Core\Model\Feed\State\Error;
 use Pureclarity\Core\Model\Feed\TypeHandler;
+use Magento\Store\Model\App\Emulation;
+use Magento\Store\Model\StoreManagerInterface;
 use Pureclarity\Core\Api\FeedDataManagementInterface;
 use Pureclarity\Core\Api\FeedManagementInterface;
 use PureClarity\Api\Feed\Feed;
@@ -73,6 +79,12 @@ class RunnerTest extends TestCase
     /** @var MockObject|TypeHandler */
     private $feedTypeHandler;
 
+    /** @var MockObject|StoreManagerInterface */
+    private $storeManager;
+
+    /** @var MockObject|Emulation */
+    private $appEmulation;
+
     protected function setUp(): void
     {
         $this->coreHelper = $this->getMockBuilder(Data::class)
@@ -115,6 +127,14 @@ class RunnerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->appEmulation = $this->getMockBuilder(Emulation::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->object = new Runner(
             $this->coreHelper,
             $this->coreFeedFactory,
@@ -125,7 +145,9 @@ class RunnerTest extends TestCase
             $this->feedRunDate,
             $this->feedProgress,
             $this->feedError,
-            $this->feedTypeHandler
+            $this->feedTypeHandler,
+            $this->storeManager,
+            $this->appEmulation
         );
     }
 
@@ -148,13 +170,40 @@ class RunnerTest extends TestCase
     }
 
     /**
+     * Sets up a StoreInterface and store manager getStore
+     * @param bool $error
+     * @return StoreInterface|MockObject
+     */
+    public function setupStore(bool $error = false)
+    {
+        $store = $this->createMock(StoreInterface::class);
+
+        $store->method('getId')
+            ->willReturn(self::STORE_ID);
+
+        $getStore = $this->storeManager->expects(self::once())
+            ->method('getStore')
+            ->with(self::STORE_ID);
+
+        if ($error) {
+            $getStore->willThrowException(
+                new NoSuchEntityException(new Phrase('A Store Error'))
+            );
+        } else {
+            $getStore->willReturn($store);
+        }
+
+        return $store;
+    }
+
+    /**
      * Sets up feed handler mock
      * @param string $type
      * @param int $numPages
      * @param int $pageSize
      * @param string $error
      */
-    public function setupFeedHandler(string $type, int $numPages, int $pageSize, string $error = ''): void
+    public function setupFeedHandler($store, string $type, int $numPages, int $pageSize, string $error = ''): void
     {
         $feedDataHandler = $this->getMockBuilder(FeedDataManagementInterface::class)
             ->disableOriginalConstructor()
@@ -172,6 +221,10 @@ class RunnerTest extends TestCase
             ->method('isEnabled')
             ->with(self::STORE_ID)
             ->willReturn(true);
+
+        $feedHandler->expects(self::exactly(2))
+            ->method('requiresEmulation')
+            ->willReturn($type === Feed::FEED_TYPE_PRODUCT);
 
         $feedHandler->expects(self::once())
             ->method('getFeedDataHandler')
@@ -230,7 +283,7 @@ class RunnerTest extends TestCase
 
                         $feedRowDataHandler->expects(self::at($x))
                             ->method('getRowData')
-                            ->with(self::STORE_ID, $item)
+                            ->with($store, $item)
                             ->willReturn($item);
                     }
                 }
@@ -308,8 +361,9 @@ class RunnerTest extends TestCase
      */
     public function testSendBrandFeed(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
-        $this->setupFeedHandler(Feed::FEED_TYPE_BRAND, 2, 2);
+        $this->setupFeedHandler($store, Feed::FEED_TYPE_BRAND, 2, 2);
         $this->setupFeedProgress(Feed::FEED_TYPE_BRAND, [0,50,100]);
         $this->object->sendFeed(self::STORE_ID, Feed::FEED_TYPE_BRAND);
     }
@@ -319,10 +373,51 @@ class RunnerTest extends TestCase
      */
     public function testSendUserFeed(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
-        $this->setupFeedHandler(Feed::FEED_TYPE_USER, 2, 2);
+        $this->setupFeedHandler($store, Feed::FEED_TYPE_USER, 2, 2);
         $this->setupFeedProgress(Feed::FEED_TYPE_USER, [0,50,100]);
         $this->object->sendFeed(self::STORE_ID, Feed::FEED_TYPE_USER);
+    }
+
+    /**
+     * Tests that the product feed gets sent
+     */
+    public function testSendProductFeed(): void
+    {
+        $store = $this->setupStore();
+        $this->setupConfig();
+        $this->setupFeedHandler($store, Feed::FEED_TYPE_PRODUCT, 2, 2);
+        $this->setupFeedProgress(Feed::FEED_TYPE_PRODUCT, [0,50,100]);
+
+        $this->appEmulation->expects(self::once())
+            ->method('startEnvironmentEmulation')
+            ->with(self::STORE_ID, Area::AREA_FRONTEND, true);
+
+        $this->appEmulation->expects(self::once())
+            ->method('stopEnvironmentEmulation');
+
+        $this->object->sendFeed(self::STORE_ID, Feed::FEED_TYPE_PRODUCT);
+    }
+
+    /**
+     * Tests that the user feed gets sent - and that app emulation stops if an exception happens
+     */
+    public function testSendProductFeedException(): void
+    {
+        $store = $this->setupStore();
+        $this->setupConfig();
+        $this->setupFeedHandler($store, Feed::FEED_TYPE_PRODUCT, 2, 2, 'An error');
+        $this->setupFeedProgress(Feed::FEED_TYPE_PRODUCT, [0]);
+
+        $this->appEmulation->expects(self::once())
+            ->method('startEnvironmentEmulation')
+            ->with(self::STORE_ID, Area::AREA_FRONTEND, true);
+
+        $this->appEmulation->expects(self::once())
+            ->method('stopEnvironmentEmulation');
+
+        $this->object->sendFeed(self::STORE_ID, Feed::FEED_TYPE_PRODUCT);
     }
 
     /**
@@ -330,8 +425,9 @@ class RunnerTest extends TestCase
      */
     public function testSendFeedException(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
-        $this->setupFeedHandler(Feed::FEED_TYPE_USER, 2, 2, 'An Error');
+        $this->setupFeedHandler($store, Feed::FEED_TYPE_USER, 2, 2, 'An Error');
         $this->setupFeedProgress(Feed::FEED_TYPE_USER, [0]);
 
         $this->logger->expects(self::once())
@@ -341,6 +437,38 @@ class RunnerTest extends TestCase
         $this->feedError->expects(self::once())
             ->method('saveFeedError')
             ->with(self::STORE_ID, Feed::FEED_TYPE_USER, 'An Error');
+
+        $this->object->sendFeed(self::STORE_ID, Feed::FEED_TYPE_USER);
+    }
+
+    /**
+     * Tests that the user feed doesnt when a store exception happens
+     */
+    public function testSendFeedStoreException(): void
+    {
+        $this->logger->expects(self::once())
+            ->method('error')
+            ->with('PureClarity: Error with ' . Feed::FEED_TYPE_USER . ' feed: A Store Error');
+
+        $this->feedError->expects(self::once())
+            ->method('saveFeedError')
+            ->with(self::STORE_ID, Feed::FEED_TYPE_USER, 'A Store Error');
+
+        $feedHandler = $this->createMock(FeedManagementInterface::class);
+
+        $feedHandler->expects(self::once())
+            ->method('isEnabled')
+            ->with(self::STORE_ID)
+            ->willReturn(true);
+
+        $this->feedTypeHandler->method('getFeedHandler')
+            ->with(Feed::FEED_TYPE_USER)
+            ->willReturn($feedHandler);
+
+        $feedHandler->expects(self::never())
+            ->method('getFeedDataHandler');
+
+        $this->setupStore(true);
 
         $this->object->sendFeed(self::STORE_ID, Feed::FEED_TYPE_USER);
     }

--- a/Test/Unit/Model/Feed/RunnerTest.php
+++ b/Test/Unit/Model/Feed/RunnerTest.php
@@ -29,6 +29,7 @@ use Pureclarity\Core\Api\FeedDataManagementInterface;
 use Pureclarity\Core\Api\FeedManagementInterface;
 use PureClarity\Api\Feed\Feed;
 use Pureclarity\Core\Api\FeedRowDataManagementInterface;
+use ReflectionException;
 
 /**
  * Class RunnerTest
@@ -173,6 +174,7 @@ class RunnerTest extends TestCase
      * Sets up a StoreInterface and store manager getStore
      * @param bool $error
      * @return StoreInterface|MockObject
+     * @throws ReflectionException
      */
     public function setupStore(bool $error = false)
     {
@@ -273,7 +275,7 @@ class RunnerTest extends TestCase
 
                     $feedDataHandler->expects(self::at($page))
                         ->method('getPageData')
-                        ->with(self::STORE_ID, $page)
+                        ->with($store, $page)
                         ->willReturn($itemData);
 
                     foreach ($itemData as $x => $item) {

--- a/Test/Unit/Model/Feed/Type/Brand/FeedDataTest.php
+++ b/Test/Unit/Model/Feed/Type/Brand/FeedDataTest.php
@@ -6,6 +6,7 @@
 
 namespace Pureclarity\Core\Test\Unit\Model\Feed\Type\Brand;
 
+use Magento\Store\Api\Data\StoreInterface;
 use PHPUnit\Framework\TestCase;
 use Pureclarity\Core\Model\Feed\Type\Brand\FeedData;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -20,6 +21,7 @@ use Magento\Framework\Phrase;
 use Magento\Catalog\Model\Category;
 use Magento\Framework\Exception\LocalizedException;
 use PureClarity\Api\Feed\Feed;
+use ReflectionException;
 
 /**
  * Class FeedDataTest
@@ -97,6 +99,22 @@ class FeedDataTest extends TestCase
             $this->categoryRepository,
             $this->coreConfig
         );
+    }
+
+    /**
+     * Sets up a StoreInterface
+     *
+     * @return StoreInterface|MockObject
+     * @throws ReflectionException
+     */
+    public function setupStore()
+    {
+        $store = $this->createMock(StoreInterface::class);
+
+        $store->method('getId')
+            ->willReturn('1');
+
+        return $store;
     }
 
     /**
@@ -198,9 +216,11 @@ class FeedDataTest extends TestCase
 
     /**
      * Tests that the total number of pages is returned correctly when no pages present
+     * @throws ReflectionException
      */
     public function testGetTotalPagesNoData(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
         $this->setupParentCategory();
         $this->setupCollection();
@@ -209,7 +229,7 @@ class FeedDataTest extends TestCase
             ->method('getLastPageNumber')
             ->willReturn(0);
 
-        $pages = $this->object->getTotalPages(self::STORE_ID);
+        $pages = $this->object->getTotalPages($store);
         self::assertEquals(0, $pages);
     }
 
@@ -218,6 +238,7 @@ class FeedDataTest extends TestCase
      */
     public function testGetTotalPagesWithData(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
         $this->setupParentCategory();
         $this->setupCollection();
@@ -226,15 +247,17 @@ class FeedDataTest extends TestCase
             ->method('getLastPageNumber')
             ->willReturn(5);
 
-        $pages = $this->object->getTotalPages(self::STORE_ID);
+        $pages = $this->object->getTotalPages($store);
         self::assertEquals(5, $pages);
     }
 
     /**
      * Tests that a collection exception is handled
+     * @throws ReflectionException
      */
     public function testGetTotalPagesCollectionException(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
         $this->setupParentCategory();
         $this->setupCollection(true);
@@ -250,14 +273,16 @@ class FeedDataTest extends TestCase
         $this->collection->expects(self::never())
             ->method('getLastPageNumber');
 
-        $this->object->getTotalPages(self::STORE_ID);
+        $this->object->getTotalPages($store);
     }
 
     /**
      * Tests that a category exception is handled
+     * @throws ReflectionException
      */
     public function testGetTotalPagesCategoryException(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
         $this->setupParentCategory(true);
 
@@ -272,14 +297,16 @@ class FeedDataTest extends TestCase
         $this->collection->expects(self::never())
             ->method('getLastPageNumber');
 
-        $this->object->getTotalPages(self::STORE_ID);
+        $this->object->getTotalPages($store);
     }
 
     /**
      * Tests that getPageData returns a page of data
+     * @throws ReflectionException
      */
     public function testGetPageDataWithData(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
         $this->setupParentCategory();
         $this->setupCollection();
@@ -295,15 +322,17 @@ class FeedDataTest extends TestCase
             ->method('getItems')
             ->willReturn([1,2]);
 
-        $data = $this->object->getPageData(self::STORE_ID, 1);
+        $data = $this->object->getPageData($store, 1);
         self::assertEquals([1,2], $data);
     }
 
     /**
      * Tests that getPageData returns a different page of data
+     * @throws ReflectionException
      */
     public function testGetPageDataWithDataPageTwo(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
         $this->setupParentCategory();
         $this->setupCollection();
@@ -319,15 +348,17 @@ class FeedDataTest extends TestCase
             ->method('getItems')
             ->willReturn([3,4]);
 
-        $data = $this->object->getPageData(self::STORE_ID, 2);
+        $data = $this->object->getPageData($store, 2);
         self::assertEquals([3,4], $data);
     }
 
     /**
      * Tests that a collection exception is handled
+     * @throws ReflectionException
      */
     public function testGetPageDataCollectionException(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
         $this->setupParentCategory();
         $this->setupCollection(true);
@@ -343,14 +374,16 @@ class FeedDataTest extends TestCase
         $this->collection->expects(self::never())
             ->method('getLastPageNumber');
 
-        $this->object->getPageData(self::STORE_ID, 1);
+        $this->object->getPageData($store, 1);
     }
 
     /**
      * Tests that a category exception is handled
+     * @throws ReflectionException
      */
     public function testGetPageDataCategoryException(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
         $this->setupParentCategory(true);
 
@@ -365,6 +398,6 @@ class FeedDataTest extends TestCase
         $this->collection->expects(self::never())
             ->method('getLastPageNumber');
 
-        $this->object->getPageData(self::STORE_ID, 1);
+        $this->object->getPageData($store, 1);
     }
 }

--- a/Test/Unit/Model/Feed/Type/Brand/RowDataTest.php
+++ b/Test/Unit/Model/Feed/Type/Brand/RowDataTest.php
@@ -9,7 +9,6 @@ namespace Pureclarity\Core\Test\Unit\Model\Feed\Type\Brand;
 use PHPUnit\Framework\TestCase;
 use Pureclarity\Core\Model\Feed\Type\Brand\RowData;
 use PHPUnit\Framework\MockObject\MockObject;
-use Magento\Store\Model\StoreManagerInterface;
 use Pureclarity\Core\Model\CoreConfig;
 use Magento\Catalog\Model\Category;
 use Magento\Store\Api\Data\StoreInterface;
@@ -29,24 +28,16 @@ class RowDataTest extends TestCase
     /** @var RowData */
     private $object;
 
-    /** @var MockObject|StoreManagerInterface */
-    private $storeManager;
-
     /** @var MockObject|CoreConfig */
     private $coreConfig;
 
     protected function setUp(): void
     {
-        $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $this->coreConfig = $this->getMockBuilder(CoreConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->object = new RowData(
-            $this->storeManager,
             $this->coreConfig
         );
     }
@@ -252,9 +243,10 @@ class RowDataTest extends TestCase
 
     /**
      * Sets up a StoreInterface and store manager getStore
-     * @param bool $error
+     *
+     * @return StoreInterface|MockObject
      */
-    public function setupStore(bool $error = false): void
+    public function setupStore()
     {
         $store = $this->getMockForAbstractClass(
             StoreInterface::class,
@@ -267,24 +259,12 @@ class RowDataTest extends TestCase
         );
 
         $store->method('getId')
-            ->willReturn('1');
+            ->willReturn(1);
 
         $store->method('getBaseUrl')
             ->willReturn('http://www.example.com/');
 
-        if ($error) {
-            $this->storeManager->expects(self::once())
-                ->method('getStore')
-                ->with(self::STORE_ID)
-                ->willThrowException(
-                    new NoSuchEntityException(new Phrase('An Error'))
-                );
-        } else {
-            $this->storeManager->expects(self::once())
-                ->method('getStore')
-                ->with(self::STORE_ID)
-                ->willReturn($store);
-        }
+        return $store;
     }
 
     /**
@@ -300,10 +280,11 @@ class RowDataTest extends TestCase
      */
     public function testGetRowData(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig();
         $data = $this->mockBrandData(1);
         $brand = $this->setupBrand1();
-        $rowData = $this->object->getRowData(self::STORE_ID, $brand);
+        $rowData = $this->object->getRowData($store, $brand);
         self::assertEquals($data, $rowData);
     }
 
@@ -312,10 +293,10 @@ class RowDataTest extends TestCase
      */
     public function testGetRowDataWithOptional(): void
     {
-        $this->setupStore();
+        $store = $this->setupStore();
         $data = $this->mockBrandData(2);
         $brand = $this->setupBrand2();
-        $rowData = $this->object->getRowData(self::STORE_ID, $brand);
+        $rowData = $this->object->getRowData($store, $brand);
         self::assertEquals($data, $rowData);
     }
 
@@ -325,10 +306,11 @@ class RowDataTest extends TestCase
      */
     public function testGetRowDataWithPlaceholder(): void
     {
+        $store = $this->setupStore();
         $this->setupConfig(true);
         $data = $this->mockBrandData(3);
         $brand = $this->setupBrand3();
-        $rowData = $this->object->getRowData(self::STORE_ID, $brand);
+        $rowData = $this->object->getRowData($store, $brand);
         self::assertEquals($data, $rowData);
     }
 }

--- a/Test/Unit/Model/Feed/Type/BrandTest.php
+++ b/Test/Unit/Model/Feed/Type/BrandTest.php
@@ -15,6 +15,7 @@ use Pureclarity\Core\Api\BrandFeedDataManagementInterface;
 use Pureclarity\Core\Api\BrandFeedRowDataManagementInterface;
 use Pureclarity\Core\Api\FeedManagementInterface;
 use PureClarity\Api\Feed\Feed;
+use PureClarity\Api\Feed\Type\Brand as BrandFeed;
 use Pureclarity\Core\Api\FeedDataManagementInterface;
 use Pureclarity\Core\Api\FeedRowDataManagementInterface;
 
@@ -159,7 +160,7 @@ class BrandTest extends TestCase
      */
     public function testGetFeedBuilder(): void
     {
-        $feed = $this->getMockBuilder(Feed::class)
+        $feed = $this->getMockBuilder(BrandFeed::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -173,7 +174,7 @@ class BrandTest extends TestCase
             ->willReturn($feed);
 
         $feedBuilder = $this->object->getFeedBuilder('A', 'B', 1);
-        self::assertInstanceOf(Feed::class, $feedBuilder);
+        self::assertInstanceOf(BrandFeed::class, $feedBuilder);
     }
 
     /**
@@ -190,5 +191,13 @@ class BrandTest extends TestCase
     public function testGetRowDataHandler(): void
     {
         self::assertInstanceOf(FeedRowDataManagementInterface::class, $this->object->getRowDataHandler());
+    }
+
+    /**
+     * Tests that isEnabled always returns false
+     */
+    public function testRequiresEmulation(): void
+    {
+        self::assertEquals(false, $this->object->requiresEmulation());
     }
 }

--- a/Test/Unit/Model/Feed/Type/CategoryTest.php
+++ b/Test/Unit/Model/Feed/Type/CategoryTest.php
@@ -14,6 +14,7 @@ use Pureclarity\Core\Api\CategoryFeedDataManagementInterface;
 use Pureclarity\Core\Api\CategoryFeedRowDataManagementInterface;
 use Pureclarity\Core\Api\FeedManagementInterface;
 use PureClarity\Api\Feed\Feed;
+use PureClarity\Api\Feed\Type\Category as CategoryFeed;
 use Pureclarity\Core\Api\FeedDataManagementInterface;
 use Pureclarity\Core\Api\FeedRowDataManagementInterface;
 
@@ -86,7 +87,7 @@ class CategoryTest extends TestCase
      */
     public function testGetFeedBuilder(): void
     {
-        $feed = $this->getMockBuilder(Feed::class)
+        $feed = $this->getMockBuilder(CategoryFeed::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -100,7 +101,7 @@ class CategoryTest extends TestCase
             ->willReturn($feed);
 
         $feedBuilder = $this->object->getFeedBuilder('A', 'B', 1);
-        self::assertInstanceOf(Feed::class, $feedBuilder);
+        self::assertInstanceOf(CategoryFeed::class, $feedBuilder);
     }
 
     /**
@@ -117,5 +118,13 @@ class CategoryTest extends TestCase
     public function testGetRowDataHandler(): void
     {
         self::assertInstanceOf(FeedRowDataManagementInterface::class, $this->object->getRowDataHandler());
+    }
+
+    /**
+     * Tests that isEnabled always returns false
+     */
+    public function testRequiresEmulation(): void
+    {
+        self::assertEquals(false, $this->object->requiresEmulation());
     }
 }

--- a/Test/Unit/Model/Feed/Type/Order/FeedDataTest.php
+++ b/Test/Unit/Model/Feed/Type/Order/FeedDataTest.php
@@ -6,6 +6,7 @@
 
 namespace Pureclarity\Core\Test\Unit\Model\Feed\Type\Order;
 
+use Magento\Store\Api\Data\StoreInterface;
 use PHPUnit\Framework\TestCase;
 use PureClarity\Api\Feed\Feed;
 use Pureclarity\Core\Model\Feed\Type\Order\FeedData;
@@ -16,6 +17,7 @@ use Magento\Sales\Model\ResourceModel\Order\Collection;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
+use ReflectionException;
 
 /**
  * Class FeedDataTest
@@ -70,6 +72,22 @@ class FeedDataTest extends TestCase
     }
 
     /**
+     * Sets up a StoreInterface
+     *
+     * @return StoreInterface|MockObject
+     * @throws ReflectionException
+     */
+    public function setupStore()
+    {
+        $store = $this->createMock(StoreInterface::class);
+
+        $store->method('getId')
+            ->willReturn('1');
+
+        return $store;
+    }
+
+    /**
      * Sets up the order collection
      * @param bool $error
      */
@@ -117,13 +135,14 @@ class FeedDataTest extends TestCase
      */
     public function testGetTotalPagesNoData(): void
     {
+        $store = $this->setupStore();
         $this->setupCollection();
 
         $this->collection->expects(self::once())
             ->method('getLastPageNumber')
             ->willReturn(0);
 
-        $pages = $this->object->getTotalPages(self::STORE_ID);
+        $pages = $this->object->getTotalPages($store);
         self::assertEquals(0, $pages);
     }
 
@@ -132,13 +151,14 @@ class FeedDataTest extends TestCase
      */
     public function testGetTotalPagesWithData(): void
     {
+        $store = $this->setupStore();
         $this->setupCollection();
 
         $this->collection->expects(self::once())
             ->method('getLastPageNumber')
             ->willReturn(5);
 
-        $pages = $this->object->getTotalPages(self::STORE_ID);
+        $pages = $this->object->getTotalPages($store);
         self::assertEquals(5, $pages);
     }
 
@@ -147,6 +167,7 @@ class FeedDataTest extends TestCase
      */
     public function testGetTotalPagesCollectionException(): void
     {
+        $store = $this->setupStore();
         $this->setupCollection(true);
 
         $this->logger->expects(self::once())
@@ -160,7 +181,7 @@ class FeedDataTest extends TestCase
         $this->collection->expects(self::never())
             ->method('getLastPageNumber');
 
-        $this->object->getTotalPages(self::STORE_ID);
+        $this->object->getTotalPages($store);
     }
 
     /**
@@ -168,6 +189,7 @@ class FeedDataTest extends TestCase
      */
     public function testGetPageDataWithData(): void
     {
+        $store = $this->setupStore();
         $this->setupCollection();
 
         $this->collection->expects(self::once())
@@ -181,7 +203,7 @@ class FeedDataTest extends TestCase
             ->method('getItems')
             ->willReturn([1,2]);
 
-        $data = $this->object->getPageData(self::STORE_ID, 1);
+        $data = $this->object->getPageData($store, 1);
         self::assertEquals([1,2], $data);
     }
 
@@ -190,6 +212,7 @@ class FeedDataTest extends TestCase
      */
     public function testGetPageDataWithDataPageTwo(): void
     {
+        $store = $this->setupStore();
         $this->setupCollection();
 
         $this->collection->expects(self::once())
@@ -203,7 +226,7 @@ class FeedDataTest extends TestCase
             ->method('getItems')
             ->willReturn([3,4]);
 
-        $data = $this->object->getPageData(self::STORE_ID, 2);
+        $data = $this->object->getPageData($store, 2);
         self::assertEquals([3,4], $data);
     }
 
@@ -212,6 +235,7 @@ class FeedDataTest extends TestCase
      */
     public function testGetPageDataCollectionException(): void
     {
+        $store = $this->setupStore();
         $this->setupCollection(true);
 
         $this->logger->expects(self::once())
@@ -225,6 +249,6 @@ class FeedDataTest extends TestCase
         $this->collection->expects(self::never())
             ->method('getLastPageNumber');
 
-        $this->object->getPageData(self::STORE_ID, 1);
+        $this->object->getPageData($store, 1);
     }
 }

--- a/Test/Unit/Model/Feed/Type/Order/RowDataTest.php
+++ b/Test/Unit/Model/Feed/Type/Order/RowDataTest.php
@@ -6,6 +6,7 @@
 
 namespace Pureclarity\Core\Test\Unit\Model\Feed\Type\Order;
 
+use Magento\Store\Api\Data\StoreInterface;
 use PHPUnit\Framework\TestCase;
 use Pureclarity\Core\Model\Feed\Type\Order\RowData;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -184,6 +185,8 @@ class RowDataTest extends TestCase
      */
     public function testSingleLineOrder(): void
     {
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn(1);
         $items = [[
             'id' => '1',
             'qty' => '2',
@@ -192,7 +195,7 @@ class RowDataTest extends TestCase
         ]];
         $data = $this->mockSingleLineOrder();
         $order = $this->setupOrder('000000009', '1', $items);
-        $rowData = $this->object->getRowData(1, $order);
+        $rowData = $this->object->getRowData($store, $order);
         self::assertEquals($data, $rowData);
     }
 
@@ -201,6 +204,8 @@ class RowDataTest extends TestCase
      */
     public function testGuestOrder(): void
     {
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn(1);
         $items = [[
             'id' => '1',
             'qty' => '2',
@@ -209,7 +214,7 @@ class RowDataTest extends TestCase
         ]];
         $data = $this->mockGuestOrder();
         $order = $this->setupOrder('000000010', '', $items);
-        $rowData = $this->object->getRowData(1, $order);
+        $rowData = $this->object->getRowData($store, $order);
         self::assertEquals($data, $rowData);
     }
 
@@ -218,6 +223,8 @@ class RowDataTest extends TestCase
      */
     public function testMultiLineOrder(): void
     {
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn(1);
         $items = [
             [
                 'id' => '12',
@@ -234,7 +241,7 @@ class RowDataTest extends TestCase
         ];
         $data = $this->mockMultiLineOrder();
         $order = $this->setupOrder('000000011', '2', $items);
-        $rowData = $this->object->getRowData(1, $order);
+        $rowData = $this->object->getRowData($store, $order);
         self::assertEquals($data, $rowData);
     }
 }

--- a/Test/Unit/Model/Feed/Type/OrderTest.php
+++ b/Test/Unit/Model/Feed/Type/OrderTest.php
@@ -118,4 +118,12 @@ class OrderTest extends TestCase
     {
         self::assertInstanceOf(FeedRowDataManagementInterface::class, $this->object->getRowDataHandler());
     }
+
+    /**
+     * Tests that isEnabled always returns false
+     */
+    public function testRequiresEmulation(): void
+    {
+        self::assertEquals(false, $this->object->requiresEmulation());
+    }
 }

--- a/Test/Unit/Model/Feed/Type/User/RowDataTest.php
+++ b/Test/Unit/Model/Feed/Type/User/RowDataTest.php
@@ -7,6 +7,7 @@
 namespace Pureclarity\Core\Test\Unit\Model\Feed\Type\User;
 
 use Magento\Customer\Model\Customer;
+use Magento\Store\Api\Data\StoreInterface;
 use PHPUnit\Framework\TestCase;
 use Pureclarity\Core\Model\Feed\Type\User;
 use Pureclarity\Core\Model\Feed\Type\User\RowData;
@@ -171,10 +172,12 @@ class RowDataTest extends TestCase
      */
     public function testGetRowData(): void
     {
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn(1);
         $this->setupCustomerGroups();
         $data = $this->mockCustomerData(1);
         $customer = $this->setupCustomer(1, $data);
-        $this->object->getRowData(1, $customer);
+        $this->object->getRowData($store, $customer);
     }
 
     /**
@@ -182,9 +185,11 @@ class RowDataTest extends TestCase
      */
     public function testGetRowDataWithoutOptional(): void
     {
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn(1);
         $this->setupCustomerGroups();
         $data = $this->mockCustomerData(2);
         $customer = $this->setupCustomer(2, $data);
-        $this->object->getRowData(1, $customer);
+        $this->object->getRowData($store, $customer);
     }
 }

--- a/Test/Unit/Model/Feed/Type/UserTest.php
+++ b/Test/Unit/Model/Feed/Type/UserTest.php
@@ -14,6 +14,7 @@ use Pureclarity\Core\Api\UserFeedDataManagementInterface;
 use Pureclarity\Core\Api\UserFeedRowDataManagementInterface;
 use Pureclarity\Core\Api\FeedManagementInterface;
 use PureClarity\Api\Feed\Feed;
+use PureClarity\Api\Feed\Type\User as UserFeed;
 use Pureclarity\Core\Api\FeedDataManagementInterface;
 use Pureclarity\Core\Api\FeedRowDataManagementInterface;
 
@@ -86,7 +87,7 @@ class UserTest extends TestCase
      */
     public function testGetFeedBuilder(): void
     {
-        $feed = $this->getMockBuilder(Feed::class)
+        $feed = $this->getMockBuilder(UserFeed::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -100,7 +101,7 @@ class UserTest extends TestCase
             ->willReturn($feed);
 
         $feedBuilder = $this->object->getFeedBuilder('A', 'B', 1);
-        self::assertInstanceOf(Feed::class, $feedBuilder);
+        self::assertInstanceOf(UserFeed::class, $feedBuilder);
     }
 
     /**
@@ -117,5 +118,13 @@ class UserTest extends TestCase
     public function testGetRowDataHandler(): void
     {
         self::assertInstanceOf(FeedRowDataManagementInterface::class, $this->object->getRowDataHandler());
+    }
+
+    /**
+     * Tests that isEnabled always returns false
+     */
+    public function testRequiresEmulation(): void
+    {
+        self::assertEquals(false, $this->object->requiresEmulation());
     }
 }


### PR DESCRIPTION
Improvements to feed running process (pre-cursor to product feed changes)

 - Changed feed data & feed row handlers to take a store object, rather than ID (to save repeated store-reloading)
 - Added emulation to feed running process (will be used by product feed)