### PR TITLE
feeds after signup bug

### DIFF
--- a/Model/Feed/Requester.php
+++ b/Model/Feed/Requester.php
@@ -52,9 +52,9 @@ class Requester
      * Runs all feed types for the given store
      * @param int $storeId
      */
-    public function requestFeeds(int $storeId, array $feeds): void
+    public function requestFeeds(int $storeId, array $feeds, $force = false): void
     {
-        if ($this->coreConfig->isActive($storeId)) {
+        if ($force || $this->coreConfig->isActive($storeId)) {
             $this->request->requestFeeds($storeId, $feeds);
 
             foreach (Runner::VALID_FEED_TYPES as $feed) {

--- a/Model/Signup/Process.php
+++ b/Model/Signup/Process.php
@@ -221,6 +221,6 @@ class Process
             }
         }
 
-        $this->feedRequest->requestFeeds($storeId, $feeds);
+        $this->feedRequest->requestFeeds($storeId, $feeds, true);
     }
 }

--- a/Test/Unit/Model/Feed/RequesterTest.php
+++ b/Test/Unit/Model/Feed/RequesterTest.php
@@ -97,13 +97,31 @@ class RequesterTest extends TestCase
         $this->request->expects(self::once())
             ->method('requestFeeds')
             ->with(1, Runner::VALID_FEED_TYPES);
-        
+
         $this->error->expects(self::exactly(5))
             ->method('saveFeedError');
-        
+
         $this->progress->expects(self::exactly(5))
             ->method('updateProgress');
 
         $this->object->requestFeeds(1, Runner::VALID_FEED_TYPES);
+    }
+
+    /**
+     * Tests that requestFeeds will request feeds if force is true
+     */
+    public function testRequestFeedsForced(): void
+    {
+        $this->request->expects(self::once())
+            ->method('requestFeeds')
+            ->with(1, Runner::VALID_FEED_TYPES);
+
+        $this->error->expects(self::exactly(5))
+            ->method('saveFeedError');
+
+        $this->progress->expects(self::exactly(5))
+            ->method('updateProgress');
+
+        $this->object->requestFeeds(1, Runner::VALID_FEED_TYPES, true);
     }
 }


### PR DESCRIPTION
Fixed an introduced issue where feeds wouldnt run after signup due to config not set to active (even though it is, magento has cached the value and it won't be active until next page load). Added a config bypass to feed requesting so that signup can request feeds