### PR TITLE
If category has no name, then default to the id of the category, and …

### DIFF
--- a/Model/Feed/Type/Category/RowData.php
+++ b/Model/Feed/Type/Category/RowData.php
@@ -44,7 +44,7 @@ class RowData implements CategoryFeedRowDataManagementInterface
         LoggerInterface $logger
     ) {
         $this->coreConfig = $coreConfig;
-        $this->logger     = $logger;
+        $this->logger = $logger;
     }
 
     /**
@@ -59,10 +59,17 @@ class RowData implements CategoryFeedRowDataManagementInterface
     {
         $this->logger->debug('Category Feed: Processing category ' . $row->getId() . ' (' . $row->getName() . ')');
 
+        $displayName = $row->getName();
+        $excludeFromRecommenders = false;
+        if (!$displayName) {
+            $displayName = $row->getId();
+            $excludeFromRecommenders = true;
+        }
+
         // Build data
         $categoryData = [
             'Id' => $row->getId(),
-            'DisplayName' => $row->getName(),
+            'DisplayName' => $displayName,
             'Image' => $this->getImageUrl($store, $row),
             'Description' => $row->getData('description') ?: '',
             'Link' => '/',
@@ -76,7 +83,10 @@ class RowData implements CategoryFeedRowDataManagementInterface
         }
 
         // Check whether to ignore this category in recommenders
-        if ($row->getData('pureclarity_hide_from_feed') === '1') {
+        if ($excludeFromRecommenders) {
+            $categoryData['ExcludeFromRecommenders'] = true;
+            $this->logger->debug('Category Feed: Category excluded from recommenders as has no name');
+        } else if ($row->getData('pureclarity_hide_from_feed') === '1') {
             $categoryData['ExcludeFromRecommenders'] = true;
             $this->logger->debug('Category Feed: Category excluded from recommenders by attribute');
         }

--- a/Test/Unit/Model/Feed/Type/Category/RowDataTest.php
+++ b/Test/Unit/Model/Feed/Type/Category/RowDataTest.php
@@ -106,8 +106,8 @@ class RowDataTest extends TestCase
             $categoryData['IsActive'] = false;
             // has an override image set
             $categoryData['OverrideImage'] = '//www.example.com/'
-                                           . 'catalog/pureclarity_category_image/'
-                                           . 'override-image-url.jpg';
+                . 'catalog/pureclarity_category_image/'
+                . 'override-image-url.jpg';
         }
 
         // a lower-level category, with placeholder images being sent
@@ -120,6 +120,14 @@ class RowDataTest extends TestCase
             $categoryData['Image'] = '//www.example.com/placeholder-image-url.jpg';
             // no override image, but placeholder configured
             $categoryData['OverrideImage'] = '//www.example.com/secondary-placeholder-image-url.jpg';
+        }
+
+        // a category with no name
+        if ($categoryId === 4) {
+            //no name, so defaults to category id
+            $categoryData['DisplayName'] = $categoryId;
+            // no name, so set to be excluded from recommenders
+            $categoryData['ExcludeFromRecommenders'] = true;
         }
 
         return $categoryData;
@@ -149,7 +157,7 @@ class RowDataTest extends TestCase
      * @param int $categoryId
      * @return MockObject|Category
      */
-    public function setupBaseCategory(int $categoryId)
+    public function setupBaseCategory(int $id, string $name, int $level)
     {
         $category = $this->createPartialMock(
             Category::class,
@@ -166,13 +174,13 @@ class RowDataTest extends TestCase
         );
 
         $category->method('getId')
-            ->willReturn($categoryId);
+            ->willReturn($id);
 
         $category->method('getName')
-            ->willReturn('Category ' . $categoryId);
+            ->willReturn($name);
 
         $category->method('getLevel')
-            ->willReturn($categoryId);
+            ->willReturn($level);
 
         return $category;
     }
@@ -186,7 +194,7 @@ class RowDataTest extends TestCase
     public function setupCategory1()
     {
         $categoryId = 1;
-        $category = $this->setupBaseCategory($categoryId);
+        $category = $this->setupBaseCategory($categoryId, 'Category ' . $categoryId, $categoryId);
 
         $category->expects(self::at(5))
             ->method('getData')
@@ -228,7 +236,7 @@ class RowDataTest extends TestCase
     public function setupCategory2()
     {
         $categoryId = 2;
-        $category = $this->setupBaseCategory($categoryId);
+        $category = $this->setupBaseCategory($categoryId, 'Category ' . $categoryId, $categoryId);
 
         $category->method('getImageUrl')
             ->willReturn('//www.example.com/category-' . $categoryId . 'image-url.jpg');
@@ -273,7 +281,49 @@ class RowDataTest extends TestCase
     public function setupCategory3()
     {
         $categoryId = 3;
-        $category = $this->setupBaseCategory($categoryId);
+        $category = $this->setupBaseCategory($categoryId, 'Category ' . $categoryId, $categoryId);
+
+        $category->method('getImageUrl')
+            ->willReturn(null);
+
+        $category->expects(self::at(5))
+            ->method('getData')
+            ->with('description')
+            ->willReturn('');
+
+        $category->method('getParentCategory')
+            ->willReturn($this->setupParentCategory());
+
+        $category->method('getUrl')
+            ->willReturn('//www.example.com/category-' . $categoryId);
+
+        $category->expects(self::at(9))
+            ->method('getData')
+            ->with('pureclarity_hide_from_feed')
+            ->willReturn('0');
+
+        $category->method('getIsActive')
+            ->willReturn('1');
+
+        $category->expects(self::at(11))
+            ->method('getData')
+            ->with('pureclarity_category_image')
+            ->willReturn('');
+
+        return $category;
+    }
+
+    /**
+     * Sets up a category MockObject with the following requirements:
+     *
+     * no name
+     *
+     * @return MockObject|Category
+     */
+    public function setupCategory4()
+    {
+        $categoryId = 1;
+        $category = $this->setupBaseCategory($categoryId, null, $categoryId);
 
         $category->method('getImageUrl')
             ->willReturn(null);
@@ -373,6 +423,19 @@ class RowDataTest extends TestCase
         $this->setupConfig(true);
         $data = $this->mockCategoryData(3);
         $category = $this->setupCategory3();
+        $rowData = $this->object->getRowData($store, $category);
+        self::assertEquals($data, $rowData);
+    }
+
+    /**
+     * Tests that a row of data with all the optional fields present is sent correctly
+     */
+    public function testGetRowDataWithNoName(): void
+    {
+        $store = $this->setupStore();
+        $this->setupConfig(true);
+        $data = $this->mockCategoryData(4);
+        $category = $this->setupCategory4();
         $rowData = $this->object->getRowData($store, $category);
         self::assertEquals($data, $rowData);
     }


### PR DESCRIPTION
…exclude from recommenders

Still import into PureClarity, as may be part of the category hierarchy.